### PR TITLE
Implementation of Classifier Trait (closed #19)

### DIFF
--- a/src/classifiers/classifier.rs
+++ b/src/classifiers/classifier.rs
@@ -1,0 +1,9 @@
+use crate::core::instance_header::InstanceHeader;
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+pub trait Classifier {
+    fn get_votes_for_instance(&self, instance: Box<dyn Instance>) -> Option<Vec<f64>>;
+    fn set_model_context(&mut self, header: Arc<InstanceHeader>);
+    fn train_on_instance(&mut self, instance: Box<dyn Instance>);
+}

--- a/src/classifiers/mod.rs
+++ b/src/classifiers/mod.rs
@@ -1,0 +1,1 @@
+mod classifier;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod classifiers;
 mod core;
 mod streams;
 mod utils;


### PR DESCRIPTION
This commit starts the implementation of the classifier trait, with the basic methods definitions for the naive bayes classifier implementation.

Further additions to this trait may be implemented, to include missing methods necessary for the Hoeffding Tree classifier