### PR TITLE
feat: Implementation of AttributeClassObserver

### DIFF
--- a/src/classifiers/attribute_class_observers/attribute_class_observer.rs
+++ b/src/classifiers/attribute_class_observers/attribute_class_observer.rs
@@ -1,0 +1,8 @@
+pub trait AttributeClassObserver {
+    fn observe_attribute_class(&mut self, att_val: f64, class_val: usize, weight: f64);
+    fn probability_of_attribute_value_given_class(
+        &self,
+        att_val: f64,
+        class_val: usize,
+    ) -> Option<f64>;
+}

--- a/src/classifiers/attribute_class_observers/gaussian_numeric_attribute_class_observer.rs
+++ b/src/classifiers/attribute_class_observers/gaussian_numeric_attribute_class_observer.rs
@@ -1,0 +1,201 @@
+use crate::classifiers::attribute_class_observers::attribute_class_observer::AttributeClassObserver;
+use crate::core::estimators::gaussian_estimator::GaussianEstimator;
+pub struct GaussianNumericAttributeClassObserver {
+    min_value_observed_per_class: Vec<f64>,
+    max_value_observed_per_class: Vec<f64>,
+    attribute_value_distribution_per_class: Vec<Option<GaussianEstimator>>,
+}
+
+impl GaussianNumericAttributeClassObserver {
+    pub fn new() -> Self {
+        GaussianNumericAttributeClassObserver {
+            min_value_observed_per_class: Vec::new(),
+            max_value_observed_per_class: Vec::new(),
+            attribute_value_distribution_per_class: Vec::new(),
+        }
+    }
+
+    #[inline]
+    fn ensure_class(&mut self, class_val: usize) {
+        if class_val >= self.attribute_value_distribution_per_class.len() {
+            let new_len = class_val + 1;
+            self.attribute_value_distribution_per_class
+                .resize_with(new_len, || None);
+            self.min_value_observed_per_class
+                .resize(new_len, f64::INFINITY);
+            self.max_value_observed_per_class
+                .resize(new_len, f64::NEG_INFINITY);
+        }
+    }
+}
+
+impl AttributeClassObserver for GaussianNumericAttributeClassObserver {
+    fn observe_attribute_class(&mut self, att_val: f64, class_val: usize, weight: f64) {
+        if att_val.is_nan() {
+            return;
+        }
+        let w = if weight.is_finite() {
+            weight.max(0.0)
+        } else {
+            0.0
+        };
+        if w == 0.0 {
+            return;
+        }
+
+        self.ensure_class(class_val);
+
+        let est = self.attribute_value_distribution_per_class[class_val]
+            .get_or_insert_with(GaussianEstimator::new);
+
+        if att_val < self.min_value_observed_per_class[class_val] {
+            self.min_value_observed_per_class[class_val] = att_val;
+        }
+        if att_val > self.max_value_observed_per_class[class_val] {
+            self.max_value_observed_per_class[class_val] = att_val;
+        }
+
+        est.add_observation(att_val, w);
+    }
+
+    fn probability_of_attribute_value_given_class(
+        &self,
+        att_val: f64,
+        class_val: usize,
+    ) -> Option<f64> {
+        if att_val.is_nan() {
+            return None;
+        }
+        match self.attribute_value_distribution_per_class.get(class_val) {
+            Some(Some(est)) => Some(est.probability_density(att_val)),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const EPS: f64 = 1e-9;
+
+    fn approx_eq(a: f64, b: f64, eps: f64) -> bool {
+        (a - b).abs() <= eps
+    }
+
+    #[test]
+    fn starts_empty_returns_none() {
+        let obs = GaussianNumericAttributeClassObserver::new();
+        assert!(
+            obs.probability_of_attribute_value_given_class(0.0, 0)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn lazy_init_and_pdf_reasonable() {
+        let mut obs = GaussianNumericAttributeClassObserver::new();
+
+        obs.observe_attribute_class(1.0, 0, 1.0);
+        obs.observe_attribute_class(3.0, 0, 1.0);
+        obs.observe_attribute_class(2.0, 0, 1.0);
+
+        let p_center = obs
+            .probability_of_attribute_value_given_class(2.0, 0)
+            .unwrap();
+        let p_far1 = obs
+            .probability_of_attribute_value_given_class(0.0, 0)
+            .unwrap();
+        let p_far2 = obs
+            .probability_of_attribute_value_given_class(5.0, 0)
+            .unwrap();
+        assert!(p_center > p_far1);
+        assert!(p_center > p_far2);
+
+        assert!(
+            obs.probability_of_attribute_value_given_class(2.0, 1)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn updates_min_max_per_class() {
+        let mut obs = GaussianNumericAttributeClassObserver::new();
+
+        obs.observe_attribute_class(10.0, 2, 1.0);
+        obs.observe_attribute_class(8.0, 2, 1.0);
+        obs.observe_attribute_class(12.0, 2, 1.0);
+
+        let p8 = obs
+            .probability_of_attribute_value_given_class(8.0, 2)
+            .unwrap();
+        let p12 = obs
+            .probability_of_attribute_value_given_class(12.0, 2)
+            .unwrap();
+        let p5 = obs
+            .probability_of_attribute_value_given_class(5.0, 2)
+            .unwrap();
+        let p15 = obs
+            .probability_of_attribute_value_given_class(15.0, 2)
+            .unwrap();
+        assert!(p8 > p5);
+        assert!(p12 > p15);
+    }
+
+    #[test]
+    fn ignores_nan_and_zero_weight() {
+        let mut obs = GaussianNumericAttributeClassObserver::new();
+
+        obs.observe_attribute_class(f64::NAN, 0, 1.0);
+        assert!(
+            obs.probability_of_attribute_value_given_class(0.0, 0)
+                .is_none()
+        );
+
+        obs.observe_attribute_class(10.0, 0, 0.0);
+        assert!(
+            obs.probability_of_attribute_value_given_class(10.0, 0)
+                .is_none()
+        );
+
+        obs.observe_attribute_class(10.0, 0, 2.0);
+        let p = obs
+            .probability_of_attribute_value_given_class(10.0, 0)
+            .unwrap();
+        assert!(approx_eq(p, 1.0, EPS));
+        let p_off = obs
+            .probability_of_attribute_value_given_class(9.999_999_999, 0)
+            .unwrap();
+        assert!(approx_eq(p_off, 0.0, EPS));
+    }
+
+    #[test]
+    fn class_index_out_of_bounds_returns_none() {
+        let mut obs = GaussianNumericAttributeClassObserver::new();
+        obs.observe_attribute_class(1.0, 0, 1.0);
+        assert!(
+            obs.probability_of_attribute_value_given_class(1.0, 5)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn pdf_monotonic_around_mean_for_simple_case() {
+        let mut obs = GaussianNumericAttributeClassObserver::new();
+        obs.observe_attribute_class(-1.0, 0, 1.0);
+        obs.observe_attribute_class(0.0, 0, 1.0);
+        obs.observe_attribute_class(1.0, 0, 1.0);
+
+        let p0 = obs
+            .probability_of_attribute_value_given_class(0.0, 0)
+            .unwrap();
+        let p1 = obs
+            .probability_of_attribute_value_given_class(1.0, 0)
+            .unwrap();
+        let p2 = obs
+            .probability_of_attribute_value_given_class(2.0, 0)
+            .unwrap();
+
+        assert!(p0 > p1);
+        assert!(p1 > p2);
+    }
+}

--- a/src/classifiers/attribute_class_observers/mod.rs
+++ b/src/classifiers/attribute_class_observers/mod.rs
@@ -1,0 +1,3 @@
+mod attribute_class_observer;
+mod gaussian_numeric_attribute_class_observer;
+mod nominal_attribute_class_observer;

--- a/src/classifiers/attribute_class_observers/nominal_attribute_class_observer.rs
+++ b/src/classifiers/attribute_class_observers/nominal_attribute_class_observer.rs
@@ -1,0 +1,227 @@
+use crate::classifiers::attribute_class_observers::attribute_class_observer::AttributeClassObserver;
+
+pub struct NominalAttributeClassObserver {
+    total_weight_observed: f64,
+    missing_weight_observed: f64,
+    attribute_value_distribution_per_class: Vec<Vec<f64>>,
+}
+
+impl NominalAttributeClassObserver {
+    pub fn new() -> NominalAttributeClassObserver {
+        NominalAttributeClassObserver {
+            total_weight_observed: 0.0,
+            missing_weight_observed: 0.0,
+            attribute_value_distribution_per_class: Vec::new(),
+        }
+    }
+
+    #[inline]
+    fn ensure_class(&mut self, class_val: usize) {
+        if class_val >= self.attribute_value_distribution_per_class.len() {
+            self.attribute_value_distribution_per_class
+                .resize_with(class_val + 1, Vec::new);
+        }
+    }
+
+    #[inline]
+    fn ensure_value(&mut self, class_val: usize, att_val_int: usize) {
+        self.ensure_class(class_val);
+        let row = &mut self.attribute_value_distribution_per_class[class_val];
+        if att_val_int >= row.len() {
+            row.resize(att_val_int + 1, 0.0);
+        }
+    }
+}
+
+impl AttributeClassObserver for NominalAttributeClassObserver {
+    fn observe_attribute_class(&mut self, att_val: f64, class_val: usize, weight: f64) {
+        if att_val.is_nan() {
+            self.missing_weight_observed += weight;
+        } else {
+            let att_val_int = att_val as usize;
+            self.ensure_value(class_val, att_val_int);
+            self.attribute_value_distribution_per_class[class_val][att_val_int] += weight;
+        }
+        self.total_weight_observed += weight;
+    }
+
+    fn probability_of_attribute_value_given_class(
+        &self,
+        att_val: f64,
+        class_val: usize,
+    ) -> Option<f64> {
+        if att_val.is_nan() {
+            return None;
+        }
+        let att_val_int = att_val as usize;
+        let row = self.attribute_value_distribution_per_class.get(class_val)?;
+        if row.is_empty() {
+            return None;
+        }
+        let count = row.get(att_val_int).copied().unwrap_or(0.0);
+        let sum: f64 = row.iter().copied().sum();
+        let k = row.len() as f64;
+        Some((count + 1.0) / (sum + k))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const EPS: f64 = 1e-9;
+
+    fn approx_eq(a: f64, b: f64, eps: f64) -> bool {
+        (a - b).abs() <= eps
+    }
+
+    #[test]
+    fn starts_empty() {
+        let obs = NominalAttributeClassObserver::new();
+        assert!(
+            obs.probability_of_attribute_value_given_class(0.0, 0)
+                .is_none()
+        );
+        assert!(approx_eq(obs.total_weight_observed, 0.0, EPS));
+        assert!(approx_eq(obs.missing_weight_observed, 0.0, EPS));
+        assert!(obs.attribute_value_distribution_per_class.is_empty());
+    }
+
+    #[test]
+    fn laplace_probabilities_simple_case() {
+        let mut obs = NominalAttributeClassObserver::new();
+        obs.observe_attribute_class(0.0, 0, 1.0);
+        obs.observe_attribute_class(0.0, 0, 1.0);
+        obs.observe_attribute_class(0.0, 0, 1.0);
+        obs.observe_attribute_class(1.0, 0, 1.0);
+
+        let p0 = obs
+            .probability_of_attribute_value_given_class(0.0, 0)
+            .unwrap();
+        let p1 = obs
+            .probability_of_attribute_value_given_class(1.0, 0)
+            .unwrap();
+        assert!(approx_eq(p0, 4.0 / 6.0, 1e-12));
+        assert!(approx_eq(p1, 2.0 / 6.0, 1e-12));
+
+        let row = &obs.attribute_value_distribution_per_class[0];
+        let mut sum_probs = 0.0;
+        for (val_idx, _) in row.iter().enumerate() {
+            let p = obs
+                .probability_of_attribute_value_given_class(val_idx as f64, 0)
+                .unwrap();
+            sum_probs += p;
+        }
+        assert!(approx_eq(sum_probs, 1.0, 1e-12));
+
+        assert!(approx_eq(obs.total_weight_observed, 4.0, 1e-12));
+        assert!(approx_eq(obs.missing_weight_observed, 0.0, 1e-12));
+    }
+
+    #[test]
+    fn different_classes_are_independent() {
+        let mut obs = NominalAttributeClassObserver::new();
+        obs.observe_attribute_class(0.0, 0, 1.0);
+        obs.observe_attribute_class(0.0, 0, 1.0);
+        obs.observe_attribute_class(1.0, 0, 1.0);
+        obs.observe_attribute_class(1.0, 1, 1.0);
+        obs.observe_attribute_class(1.0, 1, 1.0);
+
+        let p0_c0 = obs
+            .probability_of_attribute_value_given_class(0.0, 0)
+            .unwrap(); // (2+1)/(3+2)=3/5=0.6
+        let p1_c0 = obs
+            .probability_of_attribute_value_given_class(1.0, 0)
+            .unwrap(); // (1+1)/5=0.4
+        assert!(approx_eq(p0_c0, 0.6, 1e-12));
+        assert!(approx_eq(p1_c0, 0.4, 1e-12));
+
+        let p0_c1 = obs
+            .probability_of_attribute_value_given_class(0.0, 1)
+            .unwrap(); // (0+1)/(2+2)=0.25
+        let p1_c1 = obs
+            .probability_of_attribute_value_given_class(1.0, 1)
+            .unwrap(); // (2+1)/4=0.75
+        assert!(approx_eq(p0_c1, 0.25, 1e-12));
+        assert!(approx_eq(p1_c1, 0.75, 1e-12));
+    }
+
+    #[test]
+    fn handles_missing_values_and_weights() {
+        let mut obs = NominalAttributeClassObserver::new();
+        obs.observe_attribute_class(f64::NAN, 0, 2.5);
+        obs.observe_attribute_class(2.0, 0, 1.5);
+
+        assert!(approx_eq(obs.missing_weight_observed, 2.5, 1e-12));
+        assert!(approx_eq(obs.total_weight_observed, 4.0, 1e-12));
+        assert_eq!(obs.attribute_value_distribution_per_class.len(), 1);
+
+        let p = obs
+            .probability_of_attribute_value_given_class(2.0, 0)
+            .unwrap();
+        assert!(approx_eq(p, 2.5 / 4.5, 1e-12));
+
+        let p0 = obs
+            .probability_of_attribute_value_given_class(0.0, 0)
+            .unwrap();
+        let p1 = obs
+            .probability_of_attribute_value_given_class(1.0, 0)
+            .unwrap();
+        assert!(approx_eq(p0, 1.0 / 4.5, 1e-12));
+        assert!(approx_eq(p1, 1.0 / 4.5, 1e-12));
+
+        let row = &obs.attribute_value_distribution_per_class[0];
+        let mut sum_probs = 0.0;
+        for (val_idx, _) in row.iter().enumerate() {
+            sum_probs += obs
+                .probability_of_attribute_value_given_class(val_idx as f64, 0)
+                .unwrap();
+        }
+        assert!(approx_eq(sum_probs, 1.0, 1e-12));
+    }
+
+    #[test]
+    fn returns_none_when_class_exists_but_row_empty() {
+        let mut obs = NominalAttributeClassObserver::new();
+        obs.ensure_class(3);
+        assert!(
+            obs.probability_of_attribute_value_given_class(0.0, 3)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn probability_none_for_out_of_bounds_class() {
+        let obs = NominalAttributeClassObserver::new();
+        assert!(
+            obs.probability_of_attribute_value_given_class(0.0, 10)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn large_value_index_expands_row() {
+        let mut obs = NominalAttributeClassObserver::new();
+        obs.observe_attribute_class(7.0, 0, 2.0);
+
+        assert!(obs.attribute_value_distribution_per_class[0].len() >= 8);
+
+        let p7 = obs
+            .probability_of_attribute_value_given_class(7.0, 0)
+            .unwrap();
+        assert!(approx_eq(p7, 3.0 / 10.0, 1e-12));
+
+        let p0 = obs
+            .probability_of_attribute_value_given_class(0.0, 0)
+            .unwrap();
+        assert!(approx_eq(p0, 1.0 / 10.0, 1e-12));
+
+        let row = &obs.attribute_value_distribution_per_class[0];
+        let sum: f64 = (0..row.len())
+            .map(|i| {
+                obs.probability_of_attribute_value_given_class(i as f64, 0)
+                    .unwrap()
+            })
+            .sum();
+        assert!(approx_eq(sum, 1.0, 1e-12));
+    }
+}

--- a/src/classifiers/mod.rs
+++ b/src/classifiers/mod.rs
@@ -1,1 +1,2 @@
+mod attribute_class_observers;
 mod classifier;

--- a/src/core/estimators/gaussian_estimator.rs
+++ b/src/core/estimators/gaussian_estimator.rs
@@ -1,0 +1,196 @@
+#[derive(Clone, Debug, Default)]
+pub struct GaussianEstimator {
+    weight_sum: f64,
+    mean: f64,
+    variance_sum: f64,
+}
+
+impl GaussianEstimator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline]
+    pub fn add_observation(&mut self, value: f64, weight: f64) {
+        if value.is_infinite() || value.is_nan() {
+            return;
+        }
+
+        if self.weight_sum > 0.0 {
+            self.weight_sum += weight;
+            let last_mean = self.mean;
+            self.mean += weight * (value - last_mean) / self.weight_sum;
+            self.variance_sum += weight * (value - last_mean) * (value - self.mean);
+        } else {
+            self.mean = value;
+            self.weight_sum = weight;
+        }
+    }
+
+    pub fn get_variance(&self) -> f64 {
+        if self.weight_sum > 1.0 {
+            self.variance_sum / (self.weight_sum - 1.0)
+        } else {
+            0.0
+        }
+    }
+
+    pub fn get_std_dev(&self) -> f64 {
+        self.get_variance().sqrt()
+    }
+
+    #[inline]
+    pub fn add_observations(&mut self, observer: &GaussianEstimator) {
+        if (self.weight_sum > 0.0) && (observer.weight_sum > 0.0) {
+            let old_mean = self.mean;
+            self.mean = (self.mean * (self.weight_sum / (self.weight_sum + observer.weight_sum)))
+                + (observer.mean * (observer.weight_sum / (self.weight_sum + observer.weight_sum)));
+            self.variance_sum += observer.variance_sum
+                + (self.weight_sum * observer.weight_sum / (self.weight_sum + observer.weight_sum)
+                    * (observer.mean - old_mean).powi(2));
+            self.weight_sum += observer.weight_sum;
+        }
+    }
+
+    pub fn probability_density(&self, value: f64) -> f64 {
+        let normal_const: f64 = (2.0 * std::f64::consts::PI).sqrt();
+        if self.weight_sum > 0.0 {
+            let std_dev = self.get_std_dev();
+            if std_dev > 0.0 {
+                let diff = value - self.mean;
+                return (1.0 / (normal_const * std_dev))
+                    * ((-diff * diff) / (2.0 * std_dev * std_dev)).exp();
+            }
+            return if (value - self.mean).abs() == 0.0 {
+                1.0
+            } else {
+                0.0
+            };
+        }
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GaussianEstimator;
+
+    const EPS: f64 = 1e-9;
+
+    fn approx_eq(a: f64, b: f64, eps: f64) -> bool {
+        (a - b).abs() <= eps
+    }
+
+    #[test]
+    fn starts_empty() {
+        let g = GaussianEstimator::new();
+        assert!(approx_eq(g.get_variance(), 0.0, EPS));
+        assert!(approx_eq(g.get_std_dev(), 0.0, EPS));
+        assert!(approx_eq(g.probability_density(0.0), 0.0, EPS));
+        assert!(approx_eq(g.weight_sum, 0.0, EPS));
+    }
+
+    #[test]
+    fn single_observation_zero_variance() {
+        let mut g = GaussianEstimator::new();
+        g.add_observation(5.0, 1.0);
+
+        assert!(approx_eq(g.mean, 5.0, EPS));
+        assert!(approx_eq(g.weight_sum, 1.0, EPS));
+        assert!(approx_eq(g.get_variance(), 0.0, EPS));
+        assert!(approx_eq(g.get_std_dev(), 0.0, EPS));
+
+        assert!(approx_eq(g.probability_density(5.0), 1.0, 1e-12));
+        assert!(approx_eq(g.probability_density(4.999999), 0.0, 1e-12));
+    }
+
+    #[test]
+    fn two_observations_sample_variance_matches() {
+        let mut g = GaussianEstimator::new();
+        g.add_observation(0.0, 1.0);
+        g.add_observation(2.0, 1.0);
+
+        assert!(approx_eq(g.mean, 1.0, EPS));
+        assert!(approx_eq(g.weight_sum, 2.0, EPS));
+
+        assert!(approx_eq(g.get_variance(), 2.0, 1e-12));
+        assert!(approx_eq(g.get_std_dev(), (2.0f64).sqrt(), 1e-12));
+    }
+
+    #[test]
+    fn three_observations_variance_known() {
+        let mut g = GaussianEstimator::new();
+        g.add_observation(-1.0, 1.0);
+        g.add_observation(0.0, 1.0);
+        g.add_observation(1.0, 1.0);
+
+        assert!(approx_eq(g.mean, 0.0, EPS));
+        assert!(approx_eq(g.weight_sum, 3.0, EPS));
+        assert!(approx_eq(g.get_variance(), 1.0, 1e-12));
+        assert!(approx_eq(g.get_std_dev(), 1.0, 1e-12));
+
+        let expected = 1.0 / (2.0 * std::f64::consts::PI).sqrt();
+        assert!(approx_eq(g.probability_density(0.0), expected, 1e-9));
+    }
+
+    #[test]
+    fn weighted_data_behaves_like_repetition() {
+        let mut gw = GaussianEstimator::new();
+        gw.add_observation(0.0, 2.0);
+        gw.add_observation(2.0, 1.0);
+
+        let mut g_rep = GaussianEstimator::new();
+        g_rep.add_observation(0.0, 1.0);
+        g_rep.add_observation(0.0, 1.0);
+        g_rep.add_observation(2.0, 1.0);
+
+        assert!(approx_eq(gw.mean, g_rep.mean, 1e-12));
+        assert!(approx_eq(gw.get_variance(), g_rep.get_variance(), 1e-12));
+        assert!(approx_eq(gw.weight_sum, g_rep.weight_sum, 1e-12));
+    }
+
+    #[test]
+    fn add_observations_combines_correctly() {
+        let mut a = GaussianEstimator::new();
+        a.add_observation(0.0, 1.0);
+        a.add_observation(2.0, 1.0);
+
+        let mut b = GaussianEstimator::new();
+        b.add_observation(4.0, 1.0);
+        b.add_observation(6.0, 1.0);
+
+        let mut c = GaussianEstimator::new();
+        c.add_observation(0.0, 1.0);
+        c.add_observation(2.0, 1.0);
+        c.add_observation(4.0, 1.0);
+        c.add_observation(6.0, 1.0);
+
+        let mut combined = a.clone();
+        combined.add_observations(&b);
+
+        assert!(approx_eq(combined.mean, c.mean, 1e-12));
+        assert!(approx_eq(combined.get_variance(), c.get_variance(), 1e-12));
+        assert!(approx_eq(combined.weight_sum, c.weight_sum, 1e-12));
+    }
+
+    #[test]
+    fn ignores_invalid_values() {
+        let mut g = GaussianEstimator::new();
+        g.add_observation(f64::NAN, 1.0);
+        g.add_observation(f64::INFINITY, 1.0);
+        g.add_observation(f64::NEG_INFINITY, 1.0);
+
+        assert!(approx_eq(g.weight_sum, 0.0, EPS));
+        assert!(approx_eq(g.get_variance(), 0.0, EPS));
+        assert!(approx_eq(g.probability_density(0.0), 0.0, EPS));
+    }
+
+    #[test]
+    fn pdf_with_zero_variance_is_spike_at_mean() {
+        let mut g = GaussianEstimator::new();
+        g.add_observation(10.0, 3.0);
+        assert!(approx_eq(g.get_std_dev(), 0.0, EPS));
+        assert!(approx_eq(g.probability_density(10.0), 1.0, 1e-12));
+        assert!(approx_eq(g.probability_density(9.999999999), 0.0, 1e-12));
+    }
+}

--- a/src/core/estimators/mod.rs
+++ b/src/core/estimators/mod.rs
@@ -1,0 +1,1 @@
+pub mod gaussian_estimator;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,4 @@
 pub mod attributes;
+pub mod estimators;
 pub mod instance_header;
 pub mod instances;


### PR DESCRIPTION
This commit closes #21 by implementing the AttributeClassObserver trait and it's concrete implementation NominalAttributeClassObserver and GaussianNumericAttributeClassObserver.

These classes are essential for the future implementation of classifiers, as they are responsible for keep statistics for each attribute conditioned to a class.

This commits also include the implementation of GaussianEstimator, essential for the GaussianNumericAttributeClassObserver