### PR TITLE
feat: Implementation of SplitCriterion

### DIFF
--- a/src/classifiers/hoeffding_tree/mod.rs
+++ b/src/classifiers/hoeffding_tree/mod.rs
@@ -1,3 +1,4 @@
 mod hoeffding_tree;
 mod instance_conditional_test;
 mod nodes;
+mod split_criteria;

--- a/src/classifiers/hoeffding_tree/split_criteria/gini_split_criterion.rs
+++ b/src/classifiers/hoeffding_tree/split_criteria/gini_split_criterion.rs
@@ -1,0 +1,24 @@
+use crate::classifiers::hoeffding_tree::split_criteria::split_criterion::SplitCriterion;
+
+pub struct GiniSplitCriterion {}
+
+impl GiniSplitCriterion {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn compute_gini(&self, distribution: &Vec<f64>, distribution_sum_of_weights: f64) -> f64 {
+        let mut gini = 1.0;
+        for i in distribution {
+            let rel_freq = i / distribution_sum_of_weights;
+            gini -= rel_freq.powf(2.0);
+        }
+        gini
+    }
+}
+
+impl SplitCriterion for GiniSplitCriterion {
+    fn get_range_of_merit(&self, pre_split_distribution: &Vec<f64>) -> f64 {
+        1.0
+    }
+}

--- a/src/classifiers/hoeffding_tree/split_criteria/mod.rs
+++ b/src/classifiers/hoeffding_tree/split_criteria/mod.rs
@@ -1,0 +1,2 @@
+mod gini_split_criterion;
+mod split_criterion;

--- a/src/classifiers/hoeffding_tree/split_criteria/split_criterion.rs
+++ b/src/classifiers/hoeffding_tree/split_criteria/split_criterion.rs
@@ -1,0 +1,3 @@
+pub trait SplitCriterion {
+    fn get_range_of_merit(&self, pre_split_distribution: &Vec<f64>) -> f64;
+}


### PR DESCRIPTION
This commit closes #38 by implementing the `SplitCriterion` trait and it's concrete implementation `GiniSplitCriterion`.

For now, Hoeffding Tree will only have this criteria implemented, but this trait is open for expantion in the future as needed.