### PR TITLE
fix: Hoeffiding Tree results

### DIFF
--- a/src/classifiers/hoeffding_tree/hoeffding_tree.rs
+++ b/src/classifiers/hoeffding_tree/hoeffding_tree.rs
@@ -2,6 +2,7 @@ use crate::classifiers::Classifier;
 use crate::classifiers::attribute_class_observers::{
     AttributeClassObserver, GaussianNumericAttributeClassObserver, NominalAttributeClassObserver,
 };
+use crate::classifiers::conditional_tests::attribute_split_suggestion::AttributeSplitSuggestion;
 use crate::classifiers::hoeffding_tree::instance_conditional_test::InstanceConditionalTest;
 use crate::classifiers::hoeffding_tree::leaf_prediction_option::LeafPredictionOption;
 use crate::classifiers::hoeffding_tree::nodes::{
@@ -12,7 +13,7 @@ use crate::classifiers::hoeffding_tree::split_criteria::GiniSplitCriterion;
 use crate::classifiers::hoeffding_tree::split_criteria::SplitCriterion;
 use crate::core::instance_header::InstanceHeader;
 use crate::core::instances::Instance;
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell};
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::rc::Rc;
@@ -172,25 +173,19 @@ impl HoeffdingTree {
         Box::new(GaussianNumericAttributeClassObserver::new())
     }
 
-    pub fn compute_hoeffding_bound(&self, range: f64, confidance: f64, n: f64) -> f64 {
-        (((range * range) * (1.0 / confidance).ln()) / (2.0 * n)).sqrt()
+    pub fn compute_hoeffding_bound(&self, range: f64, confidence: f64, n: f64) -> f64 {
+        if confidence == 0.0 {
+            return (((range * range) * (1.0 / 0.0000001f64).ln()) / (2.0 * n)).sqrt();
+        }
+        (((range * range) * (1.0 / confidence).ln()) / (2.0 * n)).sqrt()
     }
 
-    fn deactivate_learning_node(
+    fn deactivate_learning_node_with_obs(
         &mut self,
-        to_deactivate: Rc<RefCell<dyn Node>>,
+        obs: Vec<f64>,
         parent: Option<Rc<RefCell<dyn Node>>>,
         parent_branch: isize,
     ) {
-        let obs = {
-            let guard = to_deactivate.borrow();
-            if let Some(active) = guard.as_any().downcast_ref::<ActiveLearningNode>() {
-                active.get_observed_class_distribution().to_vec()
-            } else {
-                return;
-            }
-        };
-
         let new_leaf = Rc::new(RefCell::new(InactiveLearningNode::new(obs)));
 
         if let Some(parent_node) = parent {
@@ -204,6 +199,28 @@ impl HoeffdingTree {
 
         self.active_leaf_node_count -= 1;
         self.inactive_leaf_node_count += 1;
+    }
+
+    fn deactivate_learning_node(
+        &mut self,
+        to_deactivate: Rc<RefCell<dyn Node>>,
+        parent: Option<Rc<RefCell<dyn Node>>>,
+        parent_branch: isize,
+    ) {
+        let obs = {
+            let guard = to_deactivate.borrow();
+            if let Some(active) = guard.as_any().downcast_ref::<ActiveLearningNode>() {
+                active.get_observed_class_distribution().to_vec()
+            } else if let Some(nb) = guard.as_any().downcast_ref::<LearningNodeNB>() {
+                nb.get_observed_class_distribution().to_vec()
+            } else if let Some(nb_adapt) = guard.as_any().downcast_ref::<LearningNodeNBAdaptive>() {
+                nb_adapt.get_observed_class_distribution().to_vec()
+            } else {
+                vec![]
+            }
+        };
+
+        self.deactivate_learning_node_with_obs(obs, parent, parent_branch);
     }
 
     pub fn activate_learning_node(
@@ -294,116 +311,189 @@ impl HoeffdingTree {
         parent: Option<Rc<RefCell<dyn Node>>>,
         parent_index: isize,
     ) {
-        let mut node_guard = node.borrow_mut();
-        if let Some(active_node) = node_guard.as_any_mut().downcast_mut::<ActiveLearningNode>() {
-            if active_node.observed_class_distribution_is_pure() {
-                return;
+        let best_suggestions = {
+            let mut guard = node.borrow_mut();
+            self.get_best_split_suggestions_from_node(&mut *guard)
+        };
+
+        let Some(mut best_suggestions) = best_suggestions else {
+            return;
+        };
+
+        best_suggestions.sort_by(|a, b| {
+            let a_merit = a.get_merit();
+            let b_merit = b.get_merit();
+
+            if a_merit.is_nan() && b_merit.is_nan() {
+                Ordering::Equal
+            } else if a_merit.is_nan() {
+                Ordering::Less
+            } else if b_merit.is_nan() {
+                Ordering::Greater
+            } else {
+                a_merit.partial_cmp(&b_merit).unwrap_or(Ordering::Equal)
+            }
+        });
+
+        let (weight_seen, class_dist) = {
+            let guard = node.borrow();
+            let dist = guard.get_observed_class_distribution().to_vec();
+
+            let weight = if let Some(active) = guard.as_any().downcast_ref::<ActiveLearningNode>() {
+                active.get_weight_seen()
+            } else if let Some(nb) = guard.as_any().downcast_ref::<LearningNodeNB>() {
+                nb.get_weight_seen()
+            } else if let Some(nb_adapt) = guard.as_any().downcast_ref::<LearningNodeNBAdaptive>() {
+                nb_adapt.get_weight_seen()
+            } else {
+                0.0
+            };
+
+            (weight, dist)
+        };
+
+        self.split_node(
+            node.clone(),
+            parent.clone(),
+            parent_index,
+            weight_seen,
+            class_dist,
+            best_suggestions,
+        )
+    }
+
+    fn split_node(
+        &mut self,
+        node_arc: Rc<RefCell<dyn Node>>,
+        parent: Option<Rc<RefCell<dyn Node>>>,
+        parent_index: isize,
+        weight_seen: f64,
+        class_dist: Vec<f64>,
+        best_suggestions: Vec<AttributeSplitSuggestion>,
+    ) {
+        if class_dist.iter().filter(|&&v| v > 0.0).count() < 2 {
+            return;
+        }
+
+        let split_criterion = self.split_criterion_option.as_ref();
+
+        let mut should_split = false;
+        if best_suggestions.len() < 2 {
+            should_split = !best_suggestions.is_empty();
+        } else {
+            let best_suggestion = best_suggestions.last().unwrap();
+            let second_best = &best_suggestions[best_suggestions.len() - 2];
+
+            let hoeffding_bound = self.compute_hoeffding_bound(
+                split_criterion.get_range_of_merit(&class_dist),
+                self.split_confidence_option,
+                weight_seen,
+            );
+            if (best_suggestion.get_merit() - second_best.get_merit() > hoeffding_bound)
+                || (hoeffding_bound < self.tie_threshold_option)
+            {
+                should_split = true;
             }
 
-            let split_criterion = self.split_criterion_option.as_ref();
-            let mut best_suggestions =
-                active_node.get_best_split_suggestions(split_criterion, self);
+            if self.remove_poor_atts_option
+                && matches!(
+                    self.leaf_prediction_option,
+                    LeafPredictionOption::MajorityClass
+                )
+            {
+                let mut poor_atts = HashSet::new();
+                let best_merit = best_suggestions.last().unwrap().get_merit();
 
-            best_suggestions.sort();
+                for s in &best_suggestions {
+                    if let Some(split_test) = s.get_split_test() {
+                        let split_atts = split_test.get_atts_test_depends_on();
+                        if split_atts.len() == 1 {
+                            if best_merit - s.get_merit() > hoeffding_bound {
+                                poor_atts.insert(split_atts[0]);
+                            }
+                        }
+                    }
+                }
 
-            let mut should_split = false;
-            if best_suggestions.len() < 2 {
-                should_split = !best_suggestions.is_empty();
-            } else {
-                let best_suggestion = best_suggestions.last().unwrap();
-                let second_best = &best_suggestions[best_suggestions.len() - 2];
+                for s in &best_suggestions {
+                    if let Some(split_test) = s.get_split_test() {
+                        let split_atts = split_test.get_atts_test_depends_on();
+                        if split_atts.len() == 1 {
+                            if best_merit - s.get_merit() < hoeffding_bound {
+                                poor_atts.remove(&split_atts[0]);
+                            }
+                        }
+                    }
+                }
 
-                let hoeffding_bound = self.compute_hoeffding_bound(
-                    split_criterion
-                        .get_range_of_merit(active_node.get_observed_class_distribution()),
-                    self.split_confidence_option,
-                    active_node.get_weight_seen(),
+                if !poor_atts.is_empty() {
+                    if let Ok(mut guard) = node_arc.try_borrow_mut() {
+                        if let Some(active) =
+                            guard.as_any_mut().downcast_mut::<ActiveLearningNode>()
+                        {
+                            for att in poor_atts {
+                                active.disable_attribute(att);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if !should_split {
+            return;
+        }
+
+        let split_decision = best_suggestions.last().unwrap();
+        if split_decision.get_split_test().is_none() {
+            self.deactivate_learning_node(node_arc.clone(), parent.clone(), parent_index);
+        } else {
+            let new_split = self.new_split_node(
+                split_decision.get_split_test().unwrap().clone_box(),
+                class_dist.clone(),
+                split_decision.number_of_splits(),
+            );
+
+            for i in 0..split_decision.number_of_splits() {
+                let new_child = self.new_learning_node_with_values(
+                    split_decision.resulting_class_distribution_from_split(i),
                 );
 
-                if (best_suggestion.get_merit() - second_best.get_merit() > hoeffding_bound)
-                    || (hoeffding_bound < self.tie_threshold_option)
-                {
-                    should_split = true;
-                }
-
-                if self.remove_poor_atts_option {
-                    let mut poor_atts = HashSet::new();
-
-                    for s in &best_suggestions {
-                        if let Some(split_test) = s.get_split_test() {
-                            let split_atts = split_test.get_atts_test_depends_on();
-                            if split_atts.len() == 1 {
-                                if best_suggestions.last().unwrap().get_merit() - s.get_merit()
-                                    > hoeffding_bound
-                                {
-                                    poor_atts.insert(split_atts[0]);
-                                }
-                            }
-                        }
-                    }
-
-                    for s in &best_suggestions {
-                        if let Some(split_test) = s.get_split_test() {
-                            let split_atts = split_test.get_atts_test_depends_on();
-                            if split_atts.len() == 1 {
-                                if best_suggestions.last().unwrap().get_merit() - s.get_merit()
-                                    < hoeffding_bound
-                                {
-                                    poor_atts.remove(&split_atts[0]);
-                                }
-                            }
-                        }
-                    }
-
-                    for att in poor_atts {
-                        active_node.disable_attribute(att)
-                    }
-                }
-
-                if should_split {
-                    let split_decision = best_suggestions.last().unwrap();
-                    if split_decision.get_split_test().is_none() {
-                        self.deactivate_learning_node(node.clone(), parent.clone(), parent_index);
-                    } else {
-                        let new_split = self.new_split_node(
-                            split_decision.get_split_test().unwrap().clone_box(),
-                            active_node.get_observed_class_distribution().to_vec(),
-                            split_decision.number_of_splits(),
-                        );
-
-                        for i in 0..split_decision.number_of_splits() {
-                            let new_child = self.new_learning_node_with_values(
-                                split_decision.resulting_class_distribution_from_split(i),
-                            );
-
-                            let mut guard = new_split.borrow_mut();
-                            if let Some(split_node) = guard.as_any_mut().downcast_mut::<SplitNode>()
-                            {
-                                split_node.set_child(i, new_child);
-                            }
-                        }
-
-                        self.active_leaf_node_count -= 1;
-                        self.decision_node_count += 1;
-                        self.active_leaf_node_count += split_decision.number_of_splits();
-
-                        if parent.is_none() {
-                            self.tree_root = Some(new_split);
-                        } else {
-                            if let Some(parent_arc) = parent {
-                                let mut guard = parent_arc.borrow_mut();
-                                if let Some(split_parent) =
-                                    guard.as_any_mut().downcast_mut::<SplitNode>()
-                                {
-                                    split_parent.set_child(parent_index as usize, new_split);
-                                }
-                            }
-                        }
-                    }
-
-                    self.enforce_tracker_limit();
+                let mut guard = new_split.borrow_mut();
+                if let Some(split_node) = guard.as_any_mut().downcast_mut::<SplitNode>() {
+                    split_node.set_child(i, new_child);
                 }
             }
+
+            self.active_leaf_node_count -= 1;
+            self.decision_node_count += 1;
+            self.active_leaf_node_count += split_decision.number_of_splits();
+
+            if parent.is_none() {
+                self.tree_root = Some(new_split);
+            } else if let Some(parent_arc) = parent {
+                let mut guard = parent_arc.borrow_mut();
+                if let Some(split_parent) = guard.as_any_mut().downcast_mut::<SplitNode>() {
+                    split_parent.set_child(parent_index as usize, new_split);
+                }
+            }
+        }
+
+        self.enforce_tracker_limit();
+    }
+
+    fn get_best_split_suggestions_from_node(
+        &self,
+        node: &mut dyn Node,
+    ) -> Option<Vec<AttributeSplitSuggestion>> {
+        if let Some(a) = node.as_any_mut().downcast_mut::<ActiveLearningNode>() {
+            Some(a.get_best_split_suggestions(self.split_criterion_option.as_ref(), self))
+        } else if let Some(n) = node.as_any_mut().downcast_mut::<LearningNodeNB>() {
+            Some(n.get_best_split_suggestions(self.split_criterion_option.as_ref(), self))
+        } else if let Some(n) = node.as_any_mut().downcast_mut::<LearningNodeNBAdaptive>() {
+            Some(n.get_best_split_suggestions(self.split_criterion_option.as_ref(), self))
+        } else {
+            None
         }
     }
 
@@ -545,11 +635,11 @@ impl Classifier for HoeffdingTree {
         if let Some(root_arc) = &self.tree_root {
             let root_guard = root_arc.borrow();
             let found_node =
-                root_guard.filter_instance_to_leaf_dyn(root_arc.clone(), instance, None, -1);
+                root_guard.filter_instance_to_leaf(root_arc.clone(), instance, None, -1);
 
             let node_arc = found_node
                 .get_node()
-                .or_else(|| found_node.get_parent().map(|p| p as Rc<RefCell<dyn Node>>));
+                .or_else(|| found_node.get_parent().map(|p| p));
             if let Some(n_arc) = node_arc {
                 let node_guard = n_arc.borrow();
                 return node_guard.get_class_votes(instance, self);
@@ -567,6 +657,9 @@ impl Classifier for HoeffdingTree {
     }
 
     fn train_on_instance(&mut self, instance: &dyn Instance) {
+        if self.training_weight_seen_by_model == 6528.0 {
+            println!("Second Split")
+        }
         if self.tree_root.is_none() {
             self.tree_root = Some(self.new_learning_node());
             self.active_leaf_node_count = 1;
@@ -574,9 +667,13 @@ impl Classifier for HoeffdingTree {
 
         let found_node = {
             let root_arc = self.tree_root.as_ref().unwrap().clone();
-            let root_arc_for_call = root_arc.clone();
-            let root_guard = root_arc.borrow();
-            root_guard.filter_instance_to_leaf_dyn(root_arc_for_call, instance, None, -1)
+            let found = root_arc.clone().borrow().filter_instance_to_leaf(
+                root_arc.clone(),
+                instance,
+                None,
+                -1,
+            );
+            found
         };
 
         let leaf_node_arc = match found_node.get_node() {
@@ -611,12 +708,49 @@ impl Classifier for HoeffdingTree {
                 leaf_guard.as_any_mut().downcast_mut::<ActiveLearningNode>()
             {
                 learning_node.learn_from_instance(instance, self);
+            }
 
-                if self.growth_allowed {
-                    let weight_seen = learning_node.get_weight_seen();
-                    if weight_seen - learning_node.get_weight_seen_at_last_split_evaluation()
-                        >= self.grace_period_option as f64
-                    {
+            if self.growth_allowed
+                && (leaf_guard.as_any_mut().is::<ActiveLearningNode>()
+                    || leaf_guard.as_any_mut().is::<LearningNodeNB>()
+                    || leaf_guard.as_any_mut().is::<LearningNodeNBAdaptive>())
+            {
+                let weight_seen = if let Some(active) =
+                    leaf_guard.as_any_mut().downcast_mut::<ActiveLearningNode>()
+                {
+                    active.get_weight_seen()
+                } else if let Some(nb) = leaf_guard.as_any_mut().downcast_mut::<LearningNodeNB>() {
+                    nb.get_weight_seen()
+                } else if let Some(nb_adapt) = leaf_guard
+                    .as_any_mut()
+                    .downcast_mut::<LearningNodeNBAdaptive>()
+                {
+                    nb_adapt.get_weight_seen()
+                } else {
+                    0.0
+                };
+
+                if weight_seen > 0.0 {
+                    let threshold = {
+                        if let Some(active) =
+                            leaf_guard.as_any_mut().downcast_mut::<ActiveLearningNode>()
+                        {
+                            active.get_weight_seen_at_last_split_evaluation()
+                        } else if let Some(nb) =
+                            leaf_guard.as_any_mut().downcast_mut::<LearningNodeNB>()
+                        {
+                            nb.get_weight_seen_at_last_split_evaluation()
+                        } else if let Some(nb_adapt) = leaf_guard
+                            .as_any_mut()
+                            .downcast_mut::<LearningNodeNBAdaptive>()
+                        {
+                            nb_adapt.get_weight_seen_at_last_split_evaluation()
+                        } else {
+                            0.0
+                        }
+                    };
+
+                    if weight_seen - threshold >= self.grace_period_option as f64 {
                         drop(leaf_guard);
 
                         self.attempt_to_split(
@@ -630,6 +764,15 @@ impl Classifier for HoeffdingTree {
                             leaf_guard.as_any_mut().downcast_mut::<ActiveLearningNode>()
                         {
                             active.set_weight_seen_at_last_split_evaluation(weight_seen);
+                        } else if let Some(nb) =
+                            leaf_guard.as_any_mut().downcast_mut::<LearningNodeNB>()
+                        {
+                            nb.set_weight_seen_at_last_split_evaluation(weight_seen);
+                        } else if let Some(nb_adapt) = leaf_guard
+                            .as_any_mut()
+                            .downcast_mut::<LearningNodeNBAdaptive>()
+                        {
+                            nb_adapt.set_weight_seen_at_last_split_evaluation(weight_seen);
                         }
                     }
                 }
@@ -664,27 +807,27 @@ mod tests {
             self.weight
         }
 
-        fn set_weight(&mut self, new_value: f64) -> Result<(), Error> {
+        fn set_weight(&mut self, _new_value: f64) -> Result<(), Error> {
             Ok(())
         }
 
-        fn value_at_index(&self, index: usize) -> Option<f64> {
+        fn value_at_index(&self, _index: usize) -> Option<f64> {
             Some(1.0)
         }
 
-        fn set_value_at_index(&mut self, index: usize, new_value: f64) -> Result<(), Error> {
+        fn set_value_at_index(&mut self, _index: usize, _new_value: f64) -> Result<(), Error> {
             Ok(())
         }
 
-        fn is_missing_at_index(&self, index: usize) -> Result<bool, Error> {
+        fn is_missing_at_index(&self, _index: usize) -> Result<bool, Error> {
             Ok(false)
         }
 
-        fn attribute_at_index(&self, index: usize) -> Option<&dyn Attribute> {
+        fn attribute_at_index(&self, _index: usize) -> Option<&dyn Attribute> {
             None
         }
 
-        fn index_of_attribute(&self, attribute: &dyn Attribute) -> Option<usize> {
+        fn index_of_attribute(&self, _attribute: &dyn Attribute) -> Option<usize> {
             None
         }
 
@@ -700,7 +843,7 @@ mod tests {
             Some(self.class_val as f64)
         }
 
-        fn set_class_value(&mut self, new_value: f64) -> Result<(), Error> {
+        fn set_class_value(&mut self, _new_value: f64) -> Result<(), Error> {
             Ok(())
         }
 
@@ -736,7 +879,7 @@ mod tests {
             Some(0)
         }
 
-        fn result_known_for_instance(&self, instance: &dyn Instance) -> bool {
+        fn result_known_for_instance(&self, _instance: &dyn Instance) -> bool {
             unimplemented!()
         }
 
@@ -769,14 +912,14 @@ mod tests {
 
     struct DummyCriterion;
     impl SplitCriterion for DummyCriterion {
-        fn get_range_of_merit(&self, pre_split_distribution: &Vec<f64>) -> f64 {
+        fn get_range_of_merit(&self, _pre_split_distribution: &Vec<f64>) -> f64 {
             1.0
         }
 
         fn get_merit_of_split(
             &self,
-            pre_split_distribution: &[f64],
-            post_split_dists: &[Vec<f64>],
+            _pre_split_distribution: &[f64],
+            _post_split_dists: &[Vec<f64>],
         ) -> f64 {
             1.0
         }
@@ -785,11 +928,11 @@ mod tests {
     #[derive(Clone)]
     struct DummySplitTest;
     impl InstanceConditionalTest for DummySplitTest {
-        fn branch_for_instance(&self, instance: &dyn Instance) -> Option<usize> {
+        fn branch_for_instance(&self, _instance: &dyn Instance) -> Option<usize> {
             Some(0)
         }
 
-        fn result_known_for_instance(&self, instance: &dyn Instance) -> bool {
+        fn result_known_for_instance(&self, _instance: &dyn Instance) -> bool {
             true
         }
 
@@ -810,7 +953,7 @@ mod tests {
         }
     }
 
-    fn make_suggestion_with_merrit(merit: f64, num_splits: usize) -> AttributeSplitSuggestion {
+    fn make_suggestion_with_merit(merit: f64, num_splits: usize) -> AttributeSplitSuggestion {
         AttributeSplitSuggestion::new(
             Some(Box::new(DummySplitTest)),
             vec![vec![1.0, 2.0]; num_splits],
@@ -1089,13 +1232,13 @@ mod tests {
         tree.active_leaf_node_count = 1;
 
         {
-            let mut guard = weak_clone.borrow_mut();
+            let guard = weak_clone.borrow_mut();
             guard.get_observed_class_distribution();
         }
 
         let suggestions = vec![
-            make_suggestion_with_merrit(0.1, 2),
-            make_suggestion_with_merrit(0.9, 2),
+            make_suggestion_with_merit(0.1, 2),
+            make_suggestion_with_merit(0.9, 2),
         ];
 
         {
@@ -1135,7 +1278,7 @@ mod tests {
     }
 
     #[test]
-    fn test_attempt_to_split_does_nothing_when_pure_destribution() {
+    fn test_attempt_to_split_does_nothing_when_pure_distribution() {
         let mut tree =
             HoeffdingTree::new_with_only_leaf_prediction(LeafPredictionOption::MajorityClass);
         let active_node = Rc::new(RefCell::new(ActiveLearningNode::new(vec![10.0, 0.0])));
@@ -1184,7 +1327,7 @@ mod tests {
 
         let found1 = FoundNode::new(Some(node1.clone()), None, -1);
         let found2 = FoundNode::new(Some(node2.clone()), None, -1);
-        let learning_nodes = vec![found1, found2];
+        let _learning_nodes = vec![found1, found2];
 
         tree.tree_root = Some(node2.clone());
         tree.enforce_tracker_limit();
@@ -1209,7 +1352,7 @@ mod tests {
 
         let found1 = FoundNode::new(Some(inactive1.clone()), None, -1);
         let found2 = FoundNode::new(Some(inactive2.clone()), None, -1);
-        let learning_nodes = vec![found1, found2];
+        let _learning_nodes = vec![found1, found2];
 
         tree.enforce_tracker_limit();
 
@@ -1242,10 +1385,10 @@ mod tests {
         tree.active_leaf_node_count = 1;
         tree.inactive_leaf_node_count = 1;
 
-        let dummyfound_active = FoundNode::new(Some(active_node.clone()), None, -1);
-        let dummyfound_inactive = FoundNode::new(Some(inactive_node.clone()), None, -1);
+        let dummy_found_active = FoundNode::new(Some(active_node.clone()), None, -1);
+        let dummy_found_inactive = FoundNode::new(Some(inactive_node.clone()), None, -1);
 
-        let learning_nodes = vec![dummyfound_active, dummyfound_inactive];
+        let _learning_nodes = vec![dummy_found_active, dummy_found_inactive];
 
         tree.estimate_model_byte_sizes();
 
@@ -1256,7 +1399,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_promisse_returns_correct_value() {
+    fn test_extract_promise_returns_correct_value() {
         let node = Rc::new(RefCell::new(ActiveLearningNode::new(vec![3.0, 1.0, 2.0])));
         let found = FoundNode::new(Some(node.clone()), None, -1);
 
@@ -1264,7 +1407,7 @@ mod tests {
         assert!((promise - 3.0).abs() < 1e-12);
     }
     #[test]
-    fn test_extract_promisse_returns_zero_for_non_active_node() {
+    fn test_extract_promise_returns_zero_for_non_active_node() {
         let node = Rc::new(RefCell::new(InactiveLearningNode::new(vec![1.0, 1.0])));
         let found = FoundNode::new(Some(node.clone()), None, -1);
 

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_binary_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_binary_test.rs
@@ -24,13 +24,17 @@ impl InstanceConditionalTest for NominalAttributeBinaryTest {
             self.attribute_index + 1
         };
 
-        if instance.is_missing_at_index(index).ok()? {
+        if instance.is_missing_at_index(index).unwrap_or(true) {
             return None;
         }
 
         let value = instance.value_at_index(index)?;
 
-        Some((value as usize != self.attribute_value) as usize)
+        if value as usize == self.attribute_value {
+            Some(0)
+        } else {
+            Some(1)
+        }
     }
 
     fn result_known_for_instance(&self, instance: &dyn Instance) -> bool {

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/numeric_attribute_binary_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/numeric_attribute_binary_test.rs
@@ -20,12 +20,18 @@ impl NumericAttributeBinaryTest {
 
 impl InstanceConditionalTest for NumericAttributeBinaryTest {
     fn branch_for_instance(&self, instance: &dyn Instance) -> Option<usize> {
+        let index = self.attribute_index;
+
+        if instance.is_missing_at_index(index).unwrap_or(true) {
+            return None;
+        }
+
         let value = instance.value_at_index(self.attribute_index)?;
 
-        if value == self.attribute_value as f64 {
+        if value == self.attribute_value {
             return Some(if self.equals_passes_test { 0 } else { 1 });
         }
-        if value < self.attribute_value as f64 {
+        if value < self.attribute_value {
             return Some(0);
         }
         Some(1)
@@ -204,7 +210,7 @@ mod tests {
         let test = NumericAttributeBinaryTest::new(0, 3.5, true);
         assert_eq!(
             test.calc_byte_size(),
-            std::mem::size_of::<NumericAttributeBinaryTest>()
+            size_of::<NumericAttributeBinaryTest>()
         );
     }
 

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/active_learning_node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/active_learning_node.rs
@@ -110,22 +110,13 @@ impl Node for ActiveLearningNode {
     }
 
     fn filter_instance_to_leaf(
-        self_arc: Rc<RefCell<Self>>,
-        instance: &dyn Instance,
-        parent: Option<Rc<RefCell<dyn Node>>>,
-        parent_branch: isize,
-    ) -> FoundNode {
-        FoundNode::new(Some(self_arc), parent, parent_branch)
-    }
-
-    fn filter_instance_to_leaf_dyn(
         &self,
-        self_arc_dyn: Rc<RefCell<dyn Node>>,
+        self_arc: Rc<RefCell<dyn Node>>,
         _instance: &dyn Instance,
         parent: Option<Rc<RefCell<dyn Node>>>,
         parent_branch: isize,
     ) -> FoundNode {
-        FoundNode::new(Some(self_arc_dyn), parent, parent_branch)
+        FoundNode::new(Some(self_arc), parent, parent_branch)
     }
 
     fn get_observed_class_distribution_at_leaves_reachable_through_this_node(&self) -> Vec<f64> {

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/inactive_learning_node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/inactive_learning_node.rs
@@ -33,22 +33,13 @@ impl Node for InactiveLearningNode {
     }
 
     fn filter_instance_to_leaf(
-        self_arc: Rc<RefCell<Self>>,
-        instance: &dyn Instance,
-        parent: Option<Rc<RefCell<dyn Node>>>,
-        parent_branch: isize,
-    ) -> FoundNode {
-        FoundNode::new(Some(self_arc), parent, parent_branch)
-    }
-
-    fn filter_instance_to_leaf_dyn(
         &self,
-        self_arc_dyn: Rc<RefCell<dyn Node>>,
+        self_arc: Rc<RefCell<dyn Node>>,
         _instance: &dyn Instance,
         parent: Option<Rc<RefCell<dyn Node>>>,
         parent_branch: isize,
     ) -> FoundNode {
-        FoundNode::new(Some(self_arc_dyn), parent, parent_branch)
+        FoundNode::new(Some(self_arc), parent, parent_branch)
     }
 
     fn get_observed_class_distribution_at_leaves_reachable_through_this_node(&self) -> Vec<f64> {

--- a/src/classifiers/hoeffding_tree/nodes/node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/node.rs
@@ -5,21 +5,13 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-pub trait Node {
+pub trait Node: Any {
     fn get_observed_class_distribution(&self) -> &Vec<f64>;
     fn is_leaf(&self) -> bool;
     fn filter_instance_to_leaf(
-        self_arc: Rc<RefCell<Self>>,
-        instance: &dyn Instance,
-        parent: Option<Rc<RefCell<dyn Node>>>,
-        parent_branch: isize,
-    ) -> FoundNode
-    where
-        Self: Sized;
-    fn filter_instance_to_leaf_dyn(
         &self,
-        self_arc_dyn: Rc<RefCell<dyn Node>>,
-        _instance: &dyn Instance,
+        self_arc: Rc<RefCell<dyn Node>>,
+        instance: &dyn Instance,
         parent: Option<Rc<RefCell<dyn Node>>>,
         parent_branch: isize,
     ) -> FoundNode;

--- a/src/tasks/prequential_evaluator.rs
+++ b/src/tasks/prequential_evaluator.rs
@@ -106,6 +106,11 @@ impl PrequentialEvaluator {
             };
             self.processed += 1;
 
+            // TODO: Remove this
+            if self.processed == 581012 {
+                println!("last element");
+            }
+
             let votes = self.learner.get_votes_for_instance(&*instance);
 
             self.evaluator.add_result(&*instance, votes);


### PR DESCRIPTION
This commit closes #62 by fixing issues in the Hoeffding Tree training. The problem was in the tree split function, that did not check for all the leaf types and didn't split the learning nodes correctly