### PR TITLE
feat: Implementation of `calc_memory_size` for `NaiveBayes` classifier

### DIFF
--- a/src/classifiers/attribute_class_observers/attribute_class_observer.rs
+++ b/src/classifiers/attribute_class_observers/attribute_class_observer.rs
@@ -16,7 +16,7 @@ pub trait AttributeClassObserver {
         att_index: usize,
         binary_only: bool,
     ) -> Option<AttributeSplitSuggestion>;
-    fn estimate_size_bytes(&self) -> usize;
+    fn calc_memory_size(&self) -> usize;
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }

--- a/src/classifiers/attribute_class_observers/gaussian_numeric_attribute_class_observer.rs
+++ b/src/classifiers/attribute_class_observers/gaussian_numeric_attribute_class_observer.rs
@@ -174,7 +174,7 @@ impl AttributeClassObserver for GaussianNumericAttributeClassObserver {
         best
     }
 
-    fn estimate_size_bytes(&self) -> usize {
+    fn calc_memory_size(&self) -> usize {
         let mut total = size_of::<Self>();
 
         total += self.min_value_observed_per_class.len() * size_of::<f64>();
@@ -184,7 +184,7 @@ impl AttributeClassObserver for GaussianNumericAttributeClassObserver {
 
         for est_opt in &self.attribute_value_distribution_per_class {
             if let Some(est) = est_opt {
-                total += est.estimate_size_bytes();
+                total += est.calc_memory_size();
             }
         }
 

--- a/src/classifiers/attribute_class_observers/nominal_attribute_class_observer.rs
+++ b/src/classifiers/attribute_class_observers/nominal_attribute_class_observer.rs
@@ -154,7 +154,7 @@ impl AttributeClassObserver for NominalAttributeClassObserver {
         best
     }
 
-    fn estimate_size_bytes(&self) -> usize {
+    fn calc_memory_size(&self) -> usize {
         let mut total = size_of::<Self>();
 
         for inner in &self.attribute_value_distribution_per_class {

--- a/src/classifiers/attribute_class_observers/null_attribute_class_observer.rs
+++ b/src/classifiers/attribute_class_observers/null_attribute_class_observer.rs
@@ -32,7 +32,7 @@ impl AttributeClassObserver for NullAttributeClassObserver {
         None
     }
 
-    fn estimate_size_bytes(&self) -> usize {
+    fn calc_memory_size(&self) -> usize {
         size_of::<Self>()
     }
 

--- a/src/classifiers/bayes/naive_bayes.rs
+++ b/src/classifiers/bayes/naive_bayes.rs
@@ -171,6 +171,30 @@ impl Classifier for NaiveBayes {
             }
         }
     }
+
+    fn calc_memory_size(&self) -> usize {
+        let mut total: usize = 0;
+
+        total += size_of::<Option<Arc<InstanceHeader>>>();
+        if let Some(header) = &self.header {
+            total += header.calc_memory_size();
+        }
+
+        total += size_of::<Vec<f64>>();
+        total += self.observed_class_distribution.capacity() * size_of::<f64>();
+
+        total += size_of::<Vec<Option<Box<dyn AttributeClassObserver>>>>();
+        total += self.attribute_observers.capacity()
+            * size_of::<Option<Box<dyn AttributeClassObserver>>>();
+
+        for obs_opt in &self.attribute_observers {
+            if let Some(obs) = obs_opt.as_ref() {
+                total += obs.calc_memory_size();
+            }
+        }
+
+        total
+    }
 }
 
 #[cfg(test)]
@@ -279,6 +303,10 @@ mod tests {
         }
         fn arff_representation(&self) -> String {
             format!("@attribute {} numeric", self.name)
+        }
+
+        fn calc_memory_size(&self) -> usize {
+            unimplemented!()
         }
     }
 

--- a/src/classifiers/classifier.rs
+++ b/src/classifiers/classifier.rs
@@ -6,4 +6,5 @@ pub trait Classifier {
     fn get_votes_for_instance(&self, instance: &dyn Instance) -> Vec<f64>;
     fn set_model_context(&mut self, header: Arc<InstanceHeader>);
     fn train_on_instance(&mut self, instance: &dyn Instance);
+    fn calc_memory_size(&self) -> usize;
 }

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/instance_conditional_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/instance_conditional_test.rs
@@ -5,7 +5,7 @@ pub trait InstanceConditionalTest {
     fn result_known_for_instance(&self, instance: &dyn Instance) -> bool;
     fn max_branches(&self) -> usize;
     fn get_atts_test_depends_on(&self) -> Vec<usize>;
-    fn calc_byte_size(&self) -> usize;
+    fn calc_memory_size(&self) -> usize;
     fn clone_box(&self) -> Box<dyn InstanceConditionalTest>;
 }
 

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_binary_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_binary_test.rs
@@ -49,7 +49,7 @@ impl InstanceConditionalTest for NominalAttributeBinaryTest {
         vec![self.attribute_index]
     }
 
-    fn calc_byte_size(&self) -> usize {
+    fn calc_memory_size(&self) -> usize {
         size_of::<Self>()
     }
 
@@ -208,7 +208,7 @@ mod tests {
     fn test_calc_byte_size() {
         let test = NominalAttributeBinaryTest::new(0, 1);
         assert_eq!(
-            test.calc_byte_size(),
+            test.calc_memory_size(),
             std::mem::size_of::<NominalAttributeBinaryTest>()
         );
     }

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_multiway_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_multiway_test.rs
@@ -36,7 +36,7 @@ impl InstanceConditionalTest for NominalAttributeMultiwayTest {
         vec![self.attribute_index]
     }
 
-    fn calc_byte_size(&self) -> usize {
+    fn calc_memory_size(&self) -> usize {
         size_of::<Self>()
     }
 
@@ -168,7 +168,7 @@ mod tests {
     fn test_calc_byte_size() {
         let test = NominalAttributeMultiwayTest::new(0);
         assert_eq!(
-            test.calc_byte_size(),
+            test.calc_memory_size(),
             std::mem::size_of::<NominalAttributeMultiwayTest>()
         );
     }

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/numeric_attribute_binary_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/numeric_attribute_binary_test.rs
@@ -49,7 +49,7 @@ impl InstanceConditionalTest for NumericAttributeBinaryTest {
         vec![self.attribute_index]
     }
 
-    fn calc_byte_size(&self) -> usize {
+    fn calc_memory_size(&self) -> usize {
         size_of::<Self>()
     }
 
@@ -209,7 +209,7 @@ mod tests {
     fn test_calc_byte_size_returns_correct_size() {
         let test = NumericAttributeBinaryTest::new(0, 3.5, true);
         assert_eq!(
-            test.calc_byte_size(),
+            test.calc_memory_size(),
             size_of::<NumericAttributeBinaryTest>()
         );
     }

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/active_learning_node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/active_learning_node.rs
@@ -138,7 +138,7 @@ impl Node for ActiveLearningNode {
     fn observed_class_distribution_is_pure(&self) -> bool {
         Self::num_non_zero_entries(&self.observed_class_distribution) < 2
     }
-    fn calc_byte_size(&self) -> usize {
+    fn calc_memory_size(&self) -> usize {
         let mut total = size_of::<Self>();
 
         total += size_of::<Vec<f64>>();
@@ -149,7 +149,7 @@ impl Node for ActiveLearningNode {
             total += size_of::<Option<Box<dyn AttributeClassObserver>>>();
             if let Some(obs) = obs_opt {
                 total += size_of::<Box<dyn AttributeClassObserver>>();
-                total += obs.estimate_size_bytes();
+                total += obs.calc_memory_size();
             }
         }
 
@@ -159,8 +159,8 @@ impl Node for ActiveLearningNode {
         total
     }
 
-    fn calc_byte_size_including_subtree(&self) -> usize {
-        self.calc_byte_size()
+    fn calc_memory_size_including_subtree(&self) -> usize {
+        self.calc_memory_size()
     }
 }
 
@@ -377,7 +377,7 @@ mod tests {
     #[test]
     fn test_calc_byte_size_nonzero() {
         let node = ActiveLearningNode::new(vec![1.0, 2.0, 3.0]);
-        assert!(node.calc_byte_size() > 0);
+        assert!(node.calc_memory_size() > 0);
     }
 
     #[test]

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/inactive_learning_node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/inactive_learning_node.rs
@@ -61,7 +61,7 @@ impl Node for InactiveLearningNode {
     fn observed_class_distribution_is_pure(&self) -> bool {
         Self::num_non_zero_entries(&self.observed_class_distribution) < 2
     }
-    fn calc_byte_size(&self) -> usize {
+    fn calc_memory_size(&self) -> usize {
         let mut total = size_of::<Self>();
 
         total += size_of::<Vec<f64>>();
@@ -70,8 +70,8 @@ impl Node for InactiveLearningNode {
         total
     }
 
-    fn calc_byte_size_including_subtree(&self) -> usize {
-        self.calc_byte_size()
+    fn calc_memory_size_including_subtree(&self) -> usize {
+        self.calc_memory_size()
     }
 }
 
@@ -236,7 +236,7 @@ mod tests {
     #[test]
     fn test_calc_byte_size_non_zero() {
         let node = InactiveLearningNode::new(vec![1.0, 2.0, 3.0]);
-        let byte_size = node.calc_byte_size();
+        let byte_size = node.calc_memory_size();
         assert!(byte_size > 0);
     }
 

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/learning_node_nb.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/learning_node_nb.rs
@@ -126,7 +126,7 @@ impl Node for LearningNodeNB {
     fn observed_class_distribution_is_pure(&self) -> bool {
         Self::num_non_zero_entries(&self.observed_class_distribution) < 2
     }
-    fn calc_byte_size(&self) -> usize {
+    fn calc_memory_size(&self) -> usize {
         let mut total = size_of::<Self>();
 
         total += size_of::<Vec<f64>>();
@@ -137,7 +137,7 @@ impl Node for LearningNodeNB {
             total += size_of::<Option<Box<dyn AttributeClassObserver>>>();
             if let Some(observer) = obs_opt {
                 total += size_of::<Box<dyn AttributeClassObserver>>();
-                total += observer.estimate_size_bytes();
+                total += observer.calc_memory_size();
             }
         }
 
@@ -147,8 +147,8 @@ impl Node for LearningNodeNB {
         total
     }
 
-    fn calc_byte_size_including_subtree(&self) -> usize {
-        self.calc_byte_size()
+    fn calc_memory_size_including_subtree(&self) -> usize {
+        self.calc_memory_size()
     }
 }
 
@@ -367,7 +367,7 @@ mod tests {
     #[test]
     fn test_calc_byte_size_non_zero() {
         let node = LearningNodeNB::new(vec![1.0, 2.0, 3.0]);
-        let size = node.calc_byte_size();
+        let size = node.calc_memory_size();
         assert!(size > 0);
     }
 

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/learning_node_nb_adaptive.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/learning_node_nb_adaptive.rs
@@ -189,7 +189,7 @@ impl Node for LearningNodeNBAdaptive {
     fn observed_class_distribution_is_pure(&self) -> bool {
         Self::num_non_zero_entries(&self.observed_class_distribution) < 2
     }
-    fn calc_byte_size(&self) -> usize {
+    fn calc_memory_size(&self) -> usize {
         let mut total = size_of::<Self>();
 
         total += size_of::<Vec<f64>>();
@@ -200,7 +200,7 @@ impl Node for LearningNodeNBAdaptive {
             total += size_of::<Option<Box<dyn AttributeClassObserver>>>();
             if let Some(obs) = obs_opt {
                 total += size_of::<Box<dyn AttributeClassObserver>>();
-                total += obs.estimate_size_bytes();
+                total += obs.calc_memory_size();
             }
         }
 
@@ -210,8 +210,8 @@ impl Node for LearningNodeNBAdaptive {
         total
     }
 
-    fn calc_byte_size_including_subtree(&self) -> usize {
-        self.calc_byte_size()
+    fn calc_memory_size_including_subtree(&self) -> usize {
+        self.calc_memory_size()
     }
 }
 
@@ -406,7 +406,7 @@ mod tests {
     #[test]
     fn test_calc_byte_size_nonzero() {
         let node = LearningNodeNBAdaptive::new(vec![1.0, 2.0, 3.0]);
-        let size = node.calc_byte_size();
+        let size = node.calc_memory_size();
         assert!(size > 0);
     }
 

--- a/src/classifiers/hoeffding_tree/nodes/node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/node.rs
@@ -20,6 +20,6 @@ pub trait Node: Any {
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
     fn observed_class_distribution_is_pure(&self) -> bool;
-    fn calc_byte_size(&self) -> usize;
-    fn calc_byte_size_including_subtree(&self) -> usize;
+    fn calc_memory_size(&self) -> usize;
+    fn calc_memory_size_including_subtree(&self) -> usize;
 }

--- a/src/classifiers/hoeffding_tree/nodes/split_node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/split_node.rs
@@ -125,24 +125,24 @@ impl Node for SplitNode {
         Self::num_non_zero_entries(&self.observed_class_distribution) < 2
     }
 
-    fn calc_byte_size(&self) -> usize {
+    fn calc_memory_size(&self) -> usize {
         let mut total = size_of::<Self>();
 
         total += size_of::<Vec<f64>>();
         total += self.observed_class_distribution.len() * size_of::<f64>();
         total += size_of::<Option<Rc<RefCell<dyn Node>>>>();
 
-        total += self.split_test.calc_byte_size();
+        total += self.split_test.calc_memory_size();
 
         total
     }
 
-    fn calc_byte_size_including_subtree(&self) -> usize {
-        let mut total = self.calc_byte_size();
+    fn calc_memory_size_including_subtree(&self) -> usize {
+        let mut total = self.calc_memory_size();
 
         for child in &self.children {
             if let Some(child_rc) = child {
-                total += child_rc.borrow().calc_byte_size_including_subtree();
+                total += child_rc.borrow().calc_memory_size_including_subtree();
             }
         }
 
@@ -182,7 +182,7 @@ mod tests {
             vec![0]
         }
 
-        fn calc_byte_size(&self) -> usize {
+        fn calc_memory_size(&self) -> usize {
             size_of::<Self>()
         }
 

--- a/src/core/attributes/attribute.rs
+++ b/src/core/attributes/attribute.rs
@@ -9,4 +9,5 @@ pub trait Attribute: Any + Send + Sync {
     fn as_any(&self) -> &dyn Any;
 
     fn arff_representation(&self) -> String;
+    fn calc_memory_size(&self) -> usize;
 }

--- a/src/core/attributes/nominal_attribute.rs
+++ b/src/core/attributes/nominal_attribute.rs
@@ -60,4 +60,28 @@ impl Attribute for NominalAttribute {
             nominal.values.join(", ")
         )
     }
+
+    fn calc_memory_size(&self) -> usize {
+        let mut total: usize = 0;
+
+        total += size_of::<Self>();
+
+        total += self.name.capacity();
+
+        total += size_of::<Vec<String>>();
+        total += self.values.capacity() * size_of::<String>();
+        total += self.values.iter().map(|s| s.capacity()).sum::<usize>();
+
+        let cap = self.label_to_index.capacity();
+
+        total += cap * size_of::<(String, usize)>();
+
+        total += self
+            .label_to_index
+            .keys()
+            .map(|k| k.capacity())
+            .sum::<usize>();
+
+        total
+    }
 }

--- a/src/core/attributes/numeric_attribute.rs
+++ b/src/core/attributes/numeric_attribute.rs
@@ -33,4 +33,18 @@ impl Attribute for NumericAttribute {
         let numeric = self.as_any().downcast_ref::<NumericAttribute>().unwrap();
         format!("@attribute {} numeric", numeric.name())
     }
+
+    fn calc_memory_size(&self) -> usize {
+        let mut total: usize = 0;
+
+        total += size_of::<Self>();
+
+        total += self.name.capacity();
+
+        total += size_of::<Vec<u32>>();
+
+        total += self.values.capacity() * size_of::<u32>();
+
+        total
+    }
 }

--- a/src/core/estimators/gaussian_estimator.rs
+++ b/src/core/estimators/gaussian_estimator.rs
@@ -97,7 +97,7 @@ impl GaussianEstimator {
         0.0
     }
 
-    pub fn estimate_size_bytes(&self) -> usize {
+    pub fn calc_memory_size(&self) -> usize {
         size_of::<Self>()
     }
 }

--- a/src/core/instance_header.rs
+++ b/src/core/instance_header.rs
@@ -64,6 +64,22 @@ impl InstanceHeader {
         }
         0
     }
+
+    pub fn calc_memory_size(&self) -> usize {
+        let mut total: usize = 0;
+
+        total += size_of::<Self>();
+
+        total += self.relation_name.capacity();
+
+        total += self.attributes.capacity() * size_of::<AttributeRef>();
+
+        for attr_arc in &self.attributes {
+            total += attr_arc.calc_memory_size();
+        }
+
+        total
+    }
 }
 
 impl fmt::Debug for InstanceHeader {

--- a/src/streams/arff/parser.rs
+++ b/src/streams/arff/parser.rs
@@ -361,6 +361,10 @@ mod tests {
         fn arff_representation(&self) -> String {
             "@attribute d dummy".into()
         }
+
+        fn calc_memory_size(&self) -> usize {
+            size_of::<Self>()
+        }
     }
 
     #[test]

--- a/src/testing/dummies/classifier_none_votes.rs
+++ b/src/testing/dummies/classifier_none_votes.rs
@@ -12,4 +12,8 @@ impl Classifier for ClassifierNoneVotes {
     }
     fn set_model_context(&mut self, header: Arc<InstanceHeader>) {}
     fn train_on_instance(&mut self, instance: &dyn Instance) {}
+
+    fn calc_memory_size(&self) -> usize {
+        size_of::<Self>()
+    }
 }

--- a/src/testing/spies/train_spy_classifier.rs
+++ b/src/testing/spies/train_spy_classifier.rs
@@ -53,4 +53,8 @@ impl Classifier for TrainSpyClassifier {
     fn train_on_instance(&mut self, _inst: &dyn Instance) {
         self.count.fetch_add(1, Ordering::Relaxed);
     }
+
+    fn calc_memory_size(&self) -> usize {
+        unimplemented!()
+    }
 }

--- a/src/testing/stubs/oracle_classifier.rs
+++ b/src/testing/stubs/oracle_classifier.rs
@@ -28,4 +28,8 @@ impl Classifier for OracleClassifier {
     }
 
     fn train_on_instance(&mut self, instance: &dyn Instance) {}
+
+    fn calc_memory_size(&self) -> usize {
+        size_of::<Self>()
+    }
 }


### PR DESCRIPTION
This commit closes #70 by implementing `calc_memory_size` for the NaiveBayes classifier. The method name was also updated to be the same all over the project