### PR TITLE
fix: Fixed ordering in attempt to split

### DIFF
--- a/src/classifiers/hoeffding_tree/hoeffding_tree.rs
+++ b/src/classifiers/hoeffding_tree/hoeffding_tree.rs
@@ -327,9 +327,9 @@ impl HoeffdingTree {
             if a_merit.is_nan() && b_merit.is_nan() {
                 Ordering::Equal
             } else if a_merit.is_nan() {
-                Ordering::Less
-            } else if b_merit.is_nan() {
                 Ordering::Greater
+            } else if b_merit.is_nan() {
+                Ordering::Less
             } else {
                 a_merit.partial_cmp(&b_merit).unwrap_or(Ordering::Equal)
             }
@@ -649,9 +649,6 @@ impl Classifier for HoeffdingTree {
     }
 
     fn train_on_instance(&mut self, instance: &dyn Instance) {
-        if self.training_weight_seen_by_model == 6528.0 {
-            println!("Second Split")
-        }
         if self.tree_root.is_none() {
             self.tree_root = Some(self.new_learning_node());
             self.active_leaf_node_count = 1;

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/learning_node_nb_adaptive.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/learning_node_nb_adaptive.rs
@@ -47,10 +47,19 @@ impl LearningNodeNBAdaptive {
     }
 
     fn max_index(dist: &[f64]) -> Option<usize> {
-        dist.iter()
-            .enumerate()
-            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
-            .map(|(i, _)| i)
+        if dist.is_empty() {
+            return None;
+        }
+
+        let mut max_i = 0usize;
+        let mut max_v = dist[0];
+        for (i, &v) in dist.iter().enumerate().skip(1) {
+            if v > max_v {
+                max_v = v;
+                max_i = i;
+            }
+        }
+        Some(max_i)
     }
 
     fn super_learn_from_instance(


### PR DESCRIPTION
The incorrect ordering in the `attempt_to_split()` function caused inconsistencies with the MOA results. This is now fixed